### PR TITLE
Save generated composer.json into file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ There are two tools in this repository:
 Read more about this tool [here](doc/dependency-resolver.md).
 
 ```
-$ php bin/console oat:dependencies:resolve [--repository-name <repository name> | --extension-name <extension name>] [--main-branch <main repository branch>] [--dependency-branches <dependency branches>] [--repositories]
+$ php bin/console oat:dependencies:resolve [--repository-name <repository name> | --extension-name <extension name>] [--main-branch <main repository branch>] [--dependency-branches <dependency branches>] [--repositories] [--file <path to composer.json>]
 ```
 
 - `main repository name`: repository name, e.g. "oat-sa/extension-tao-testqti" of the repository to resolve.
@@ -45,6 +45,7 @@ $ php bin/console oat:dependencies:resolve [--repository-name <repository name> 
 - `main repository branch`: the branch of the extension to be resolved.
 - `dependency branches`: desired branches to download include for each dependency. In the form of "extensionName1:branchName1,extensionName2:branchName2,...", e.g. "tao:develop,taoQtiItem:fix/tao-1234,generis:10.12.14". Branches for all non given extensions will default to "develop".
 - `repositories`: flag to indicate that composer repositories information must be included. In case of private repositories, ssh authentication must be set up to use the generated composer.json file.
+- `file`: when given, the command will generate the composer.json into this file along the stdout. The target need to be writeable, and can be either a relative or absolute path. For instance, `--file output/composer.json` will generate the composer.json in the `output` directory (within the current working directory). 
 
 Only one of the two options `repository-name` and `extension-name` must be provided.
 

--- a/src/Command/DependencyResolverCommand.php
+++ b/src/Command/DependencyResolverCommand.php
@@ -180,10 +180,12 @@ class DependencyResolverCommand extends Command
     {
         $dir = dirname($file);
 
-        if (!is_dir($dir)) {
-            if (false === mkdir($dir, 0755, true)) {
-                throw new RuntimeException('Could not save the result, unable to create the required folder hierarchy.');
-            }
+        if (file_exists($file)) {
+            throw new RuntimeException('Could not save the result, the file already exists.');
+        }
+
+        if (!mkdir($dir, 0755, true) && !is_dir($dir)) {
+            throw new RuntimeException('Could not save the result, unable to create the required folder hierarchy.');
         }
 
         if (false === file_put_contents($file, $composerJson)) {

--- a/src/Command/DependencyResolverCommand.php
+++ b/src/Command/DependencyResolverCommand.php
@@ -12,6 +12,7 @@ use OAT\DependencyResolver\Extension\ExtensionFactory;
 use OAT\DependencyResolver\Manifest\DependencyResolver;
 use OAT\DependencyResolver\Repository\Entity\Repository;
 use OAT\DependencyResolver\Repository\RepositoryMapAccessor;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -76,6 +77,12 @@ class DependencyResolverCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Include repositories information (flag).'
+            )
+            ->addOption(
+                'file',
+                'f',
+                InputOption::VALUE_OPTIONAL,
+                'Save composer.json to given file.'
             );
     }
 
@@ -101,6 +108,10 @@ class DependencyResolverCommand extends Command
             $extensionBranchMap,
             $input->getOption('repositories') !== false
         );
+
+        if ($input->getOption('file')) {
+            $this->resultToFile($input->getOption('file'), $composerJson);
+        }
 
         // Outputs result.
         $output->writeln($composerJson);
@@ -157,5 +168,26 @@ class DependencyResolverCommand extends Command
         }
 
         return $extensionToBranchMap;
+    }
+
+    /**
+     * Saves the generated composer.json into a file represented by its path.
+     *
+     * @param string $file
+     * @param string $composerJson
+     */
+    protected function resultToFile(string $file, string $composerJson): void
+    {
+        $dir = dirname($file);
+
+        if (!is_dir($dir)) {
+            if (false === mkdir($dir, 0755, true)) {
+                throw new RuntimeException('Could not save the result, unable to create the required folder hierarchy.');
+            }
+        }
+
+        if (false === file_put_contents($file, $composerJson)) {
+            throw new RuntimeException('Could not save the result, unable to write the file.');
+        }
     }
 }

--- a/tests/Integration/Command/DependencyResolverCommandTest.php
+++ b/tests/Integration/Command/DependencyResolverCommandTest.php
@@ -33,6 +33,8 @@ class DependencyResolverCommandTest extends KernelTestCase
 {
     use ProtectedAccessorTrait;
 
+    const OUTPUT_FILE = 'tests/resources/composer.json';
+
     /** @var CommandTester */
     private $commandTester;
 
@@ -72,6 +74,11 @@ class DependencyResolverCommandTest extends KernelTestCase
         $this->commandTester = new CommandTester($application->find(DependencyResolverCommand::NAME));
     }
 
+    public function tearDown()
+    {
+        is_file(self::OUTPUT_FILE) && unlink(self::OUTPUT_FILE);
+    }
+
     public function testMissingArgument()
     {
         $this->expectException(ArgumentCountError::class);
@@ -109,6 +116,10 @@ class DependencyResolverCommandTest extends KernelTestCase
             json_encode($compose, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n",
             $this->commandTester->getDisplay()
         );
+
+        if (isset($options['--file'])) {
+            $this->assertTrue(file_exists($options['--file']));
+        }
     }
 
     public function workingCasesToTest()
@@ -174,7 +185,16 @@ class DependencyResolverCommandTest extends KernelTestCase
                     'oat-sa/tao-core',
                     'oat-sa/generis',
                 ]
-            ]
+            ],
+
+            'repo name file' => [
+                [
+                    '--repository-name' => 'oat-sa/generis',
+                    '--file' => self::OUTPUT_FILE
+                ],
+                ['oat-sa/generis' => 'dev-develop'],
+                [],
+            ],
         ];
     }
 


### PR DESCRIPTION
In this PR I'm introducing a new CLI option for the `resolve` command.

**New option:** 
`--file <FILENAME>`  where <FILENAME> describes the path where the generated composer.json is to be written on the disk.
To be backward compatible, the parameter is optional.

**Motivation:**
This feature comes in handy when one needs to install/update the generated dependencies right away. We do this typically in the CI environment where the different steps share generated artifacts (i.e. composer.json) through a shared volume. 